### PR TITLE
Improve Dreo fan speed handling

### DIFF
--- a/homeassistant/components/dreo/coordinator.py
+++ b/homeassistant/components/dreo/coordinator.py
@@ -13,13 +13,50 @@ from pydreo.exceptions import DreoException
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.percentage import ranged_value_to_percentage
+from homeassistant.util.percentage import ordered_list_item_to_percentage
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 UPDATE_INTERVAL = timedelta(seconds=60)
+
+
+def get_fan_model_config(model_config: dict[str, Any]) -> dict[str, Any]:
+    """Return the fan-specific model config section."""
+    if isinstance(model_config.get("fan_entity_config"), dict):
+        return model_config["fan_entity_config"]
+
+    return model_config
+
+
+def get_speed_values(model_config: dict[str, Any]) -> list[int] | None:
+    """Return normalized supported fan speed values."""
+    raw_speed_values = get_fan_model_config(model_config).get("speed_range")
+
+    if (
+        not isinstance(raw_speed_values, list | tuple)
+        or len(raw_speed_values) < 2
+    ):
+        return None
+
+    try:
+        speed_values = [int(value) for value in raw_speed_values]
+    except (TypeError, ValueError):
+        return None
+
+    if len(speed_values) == 2:
+        low, high = speed_values
+        if low < 1 or high < low:
+            return None
+
+        return list(range(low, high + 1))
+
+    normalized_speed_values = sorted(set(speed_values))
+    if normalized_speed_values[0] < 1:
+        return None
+
+    return normalized_speed_values
 
 
 @dataclass(slots=True)
@@ -46,10 +83,20 @@ class DreoFanDeviceData:
             fan_data.oscillate = bool(oscillate)
 
         if (speed := status.get("speed")) is not None:
-            speed_range = model_config.get("speed_range")
-            if speed_range:
-                fan_data.speed_percentage = int(
-                    ranged_value_to_percentage(speed_range, float(speed))
+            try:
+                speed_value = int(float(speed))
+            except (TypeError, ValueError):
+                speed_value = None
+
+            if speed_value == 0:
+                fan_data.speed_percentage = 0
+            elif (
+                speed_value is not None
+                and (speed_values := get_speed_values(model_config))
+                and speed_value in speed_values
+            ):
+                fan_data.speed_percentage = ordered_list_item_to_percentage(
+                    speed_values, speed_value
                 )
 
         return fan_data

--- a/homeassistant/components/dreo/coordinator.py
+++ b/homeassistant/components/dreo/coordinator.py
@@ -34,15 +34,12 @@ def get_speed_values(model_config: dict[str, Any]) -> list[int] | None:
     """Return normalized supported fan speed values."""
     raw_speed_values = get_fan_model_config(model_config).get("speed_range")
 
-    if (
-        not isinstance(raw_speed_values, list | tuple)
-        or len(raw_speed_values) < 2
-    ):
+    if not isinstance(raw_speed_values, list | tuple) or len(raw_speed_values) < 2:
         return None
 
     try:
         speed_values = [int(value) for value in raw_speed_values]
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
 
     if len(speed_values) == 2:
@@ -85,7 +82,7 @@ class DreoFanDeviceData:
         if (speed := status.get("speed")) is not None:
             try:
                 speed_value = int(float(speed))
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 speed_value = None
 
             if speed_value == 0:

--- a/homeassistant/components/dreo/entity.py
+++ b/homeassistant/components/dreo/entity.py
@@ -61,7 +61,7 @@ class DreoEntity(CoordinatorEntity[DreoDataUpdateCoordinator]):
             await self.coordinator.hass.async_add_executor_job(
                 partial(self._client.update_status, self._device_id, **kwargs)
             )
-            await self.coordinator.async_refresh()
+            await self.coordinator.async_request_refresh()
         except (
             DreoException,
             DreoBusinessException,

--- a/homeassistant/components/dreo/fan.py
+++ b/homeassistant/components/dreo/fan.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-import math
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.util.percentage import percentage_to_ranged_value
+from homeassistant.util.percentage import percentage_to_ordered_list_item
 
 from . import DreoConfigEntry
 from .const import (
@@ -20,7 +19,11 @@ from .const import (
     ERROR_TURN_ON_FAILED,
     FAN_DEVICE_TYPE,
 )
-from .coordinator import DreoDataUpdateCoordinator
+from .coordinator import (
+    DreoDataUpdateCoordinator,
+    get_fan_model_config,
+    get_speed_values,
+)
 from .entity import DreoEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -77,6 +80,7 @@ class DreoFan(DreoEntity, FanEntity):
     _attr_percentage = 0
     _attr_preset_mode = None
     _attr_oscillating = None
+    _attr_speed_count = 100
 
     def __init__(
         self,
@@ -87,8 +91,16 @@ class DreoFan(DreoEntity, FanEntity):
         super().__init__(device, coordinator, FAN_DEVICE_TYPE)
 
         model_config = coordinator.model_config
-        self._speed_range = model_config.get("speed_range")
-        self._attr_preset_modes = model_config.get("preset_modes")
+        fan_model_config = get_fan_model_config(model_config)
+        self._speed_values = get_speed_values(model_config) or []
+        if self._speed_values:
+            self._attr_speed_count = len(self._speed_values)
+        self._attr_preset_modes = fan_model_config.get("preset_modes")
+
+    async def async_added_to_hass(self) -> None:
+        """Register the fan and sync its initial state."""
+        await super().async_added_to_hass()
+        self._update_attributes()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -174,17 +186,24 @@ class DreoFan(DreoEntity, FanEntity):
         if not self.is_on:
             command_params["power_switch"] = True
 
-        if percentage is not None and percentage > 0 and self._speed_range:
-            speed = math.ceil(
-                percentage_to_ranged_value(self._speed_range, percentage)
+        if percentage is not None and percentage > 0 and self._speed_values:
+            speed = percentage_to_ordered_list_item(self._speed_values, percentage)
+            current_percentage = self.percentage
+            current_speed = (
+                percentage_to_ordered_list_item(self._speed_values, current_percentage)
+                if current_percentage
+                else None
             )
-            if speed > 0:
+            if speed > 0 and speed != current_speed:
                 command_params["speed"] = speed
 
         if preset_mode is not None:
             command_params["mode"] = preset_mode
         if oscillate is not None:
             command_params["oscillate"] = oscillate
+
+        if not command_params:
+            return
 
         await self.async_send_command_and_update(
             error_translation_key, **command_params

--- a/tests/components/dreo/test_config_flow.py
+++ b/tests/components/dreo/test_config_flow.py
@@ -133,7 +133,9 @@ async def test_reauth_flow_success(hass: HomeAssistant) -> None:
             "homeassistant.config_entries.ConfigEntries.async_reload",
             return_value=True,
         ),
-        patch("homeassistant.components.dreo.config_flow.DreoClient") as mock_client_class,
+        patch(
+            "homeassistant.components.dreo.config_flow.DreoClient"
+        ) as mock_client_class,
     ):
         mock_client = mock_client_class.return_value
         mock_client.login = MagicMock()

--- a/tests/components/dreo/test_coordinator.py
+++ b/tests/components/dreo/test_coordinator.py
@@ -48,6 +48,19 @@ async def test_data_type_conversion_algorithms() -> None:
     assert fan_data.speed_percentage == 50
 
 
+async def test_speed_values_list_conversion_logic() -> None:
+    """Test speed conversion from explicit supported speed values."""
+    status = {"connected": True, "power_switch": True, "speed": 7}
+    model_config = {
+        "preset_modes": ["Sleep", "Auto", "Natural", "Normal"],
+        "speed_range": [1, 3, 5, 7, 9, 12],
+    }
+
+    fan_data = DreoFanDeviceData.process_fan_data(status, model_config)
+
+    assert fan_data.speed_percentage == 66
+
+
 async def test_data_processing_with_missing_speed_range() -> None:
     """Test data processing behavior when speed_range is not in model config."""
     status = {"connected": True, "power_switch": True, "speed": 3}
@@ -87,3 +100,16 @@ async def test_process_fan_data_edge_cases() -> None:
     )
     assert fan_data_zero.oscillate is False
     assert fan_data_zero.speed_percentage == 50
+
+
+async def test_process_fan_data_zero_speed() -> None:
+    """Test zero speed is reported correctly."""
+    status = {"connected": True, "power_switch": True, "speed": 0}
+    model_config = {
+        "preset_modes": ["Sleep", "Auto", "Natural", "Normal"],
+        "speed_range": [1, 6],
+    }
+
+    fan_data = DreoFanDeviceData.process_fan_data(status, model_config)
+
+    assert fan_data.speed_percentage == 0

--- a/tests/components/dreo/test_fan.py
+++ b/tests/components/dreo/test_fan.py
@@ -9,6 +9,7 @@ from homeassistant.components.dreo.fan import async_setup_entry
 from homeassistant.components.fan import (
     ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
+    ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
     DOMAIN as FAN_DOMAIN,
 )
@@ -67,6 +68,7 @@ async def test_fan_setup_and_device_info(hass: HomeAssistant) -> None:
     assert state is not None
     assert state.state == STATE_ON
     assert state.attributes[ATTR_PERCENTAGE] == 50
+    assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(100 / 6)
     assert state.attributes[ATTR_PRESET_MODE] == "Auto"
     assert state.attributes[ATTR_OSCILLATING] is True
 
@@ -667,3 +669,48 @@ async def test_fan_execute_command_without_speed_range(hass: HomeAssistant) -> N
     mock_client.update_status.assert_called_with(
         "test-fan-no-speed-range", power_switch=True
     )
+
+
+async def test_fan_set_percentage_service_with_discrete_speed_values(
+    hass: HomeAssistant,
+) -> None:
+    """Test fan set percentage service with explicit speed values."""
+    with patch("homeassistant.components.dreo.DreoClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = MagicMock()
+        mock_client.get_devices.return_value = [
+            {
+                "deviceSn": "test-fan-discrete-speeds",
+                "model": "DR-HTF001S",
+                "deviceName": "Discrete Speed Fan",
+                "deviceType": "fan",
+                "config": {
+                    "preset_modes": ["Sleep", "Auto", "Natural", "Normal"],
+                    "speed_range": [1, 3, 5, 7, 9, 12],
+                },
+            }
+        ]
+        mock_client.get_status.return_value = {
+            "power_switch": True,
+            "connected": True,
+            "speed": 7,
+        }
+        mock_client.update_status = MagicMock()
+
+        config_entry = await init_integration(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.discrete_speed_fan")
+    assert state is not None
+    assert state.attributes[ATTR_PERCENTAGE] == 66
+    assert state.attributes[ATTR_PERCENTAGE_STEP] == pytest.approx(100 / 6)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        "set_percentage",
+        {ATTR_ENTITY_ID: "fan.discrete_speed_fan", ATTR_PERCENTAGE: 75},
+        blocking=True,
+    )
+
+    mock_client.update_status.assert_called_with("test-fan-discrete-speeds", speed=9)


### PR DESCRIPTION
## Summary
- handle fan configs that expose discrete speed values or nested fan entity config
- avoid redundant refreshes by using request refresh and skipping no-op fan commands
- add coverage for zero-speed and discrete speed percentage mapping

## Testing
- .venv/bin/python -m pytest tests/components/dreo -q